### PR TITLE
Fix hourly siren refresh

### DIFF
--- a/drivers/SmartThings/Boundary-sensors/src/boundary-siren/init.lua
+++ b/drivers/SmartThings/Boundary-sensors/src/boundary-siren/init.lua
@@ -48,10 +48,10 @@ local function device_init(self, device)
           ledEnabled = Enable_led_parameter()
         end
         device:send(Configuration:Set({parameter_number = 1, size = 4, configuration_value = ledEnabled}))
+      end
 
       log.debug("Hourly siren status refresh requested")
       device:default_refresh() -- The siren wasn't sending temperature updates unless manually refreshed
-      end
     end
   end, 'Siren Poll Schedule')
 end


### PR DESCRIPTION
## Summary
- ensure hourly siren refresh occurs even when LED preference isn't set

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d74c4328c8326837cc11ac6d0a293