### PR TITLE
Fix doc typo in Boundary siren init

### DIFF
--- a/drivers/SmartThings/Boundary-sensors/src/boundary-siren/init.lua
+++ b/drivers/SmartThings/Boundary-sensors/src/boundary-siren/init.lua
@@ -24,7 +24,7 @@ local BOUNDARY_SIREN_FINGERPRINTS = {
 --- Determine whether the passed device is boundary siren
 ---
 --- @param driver Driver driver instance
---- @param device Device device isntance
+--- @param device Device device instance
 --- @return boolean true if the device proper, else false
 local function can_handle_boundary_siren(opts, driver, device, ...)
   for _, fingerprint in ipairs(BOUNDARY_SIREN_FINGERPRINTS) do


### PR DESCRIPTION
## Summary
- fix spelling in param block for boundary-siren init

## Testing
- `make test` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_686d774c7cc08326a0d02ab5c019b6a6