### PR TITLE
Fix repeated word in wake up interval description

### DIFF
--- a/drivers/SmartThings/Boundary-sensors/profiles/boundary-contact.yml
+++ b/drivers/SmartThings/Boundary-sensors/profiles/boundary-contact.yml
@@ -31,10 +31,9 @@ preferences:
       default: 1
   - name: "wakeUpInterval"
     title: "Wake up interval"
-    description: "The shorter the time, the more frequently the the device will report measurements."
+    description: "The shorter the time, the more frequently the device will report measurements."
     required: false
     preferenceType: integer
     definition:
       minimum: 60
-      maximum: 3600
-      default: 380
+      maximum: 3600      default: 380

--- a/drivers/SmartThings/Boundary-sensors/profiles/boundary-motion.yml
+++ b/drivers/SmartThings/Boundary-sensors/profiles/boundary-motion.yml
@@ -31,7 +31,7 @@ preferences:
       default: 1
   - name: "wakeUpInterval"
     title: "Wake up interval"
-    description: "The shorter the time, the more frequently the the device will report measurements."
+    description: "The shorter the time, the more frequently the device will report measurements."
     required: false
     preferenceType: integer
     definition:
@@ -55,5 +55,4 @@ preferences:
     preferenceType: integer
     definition:
       minimum: 0
-      maximum: 180
-      default: 20
+      maximum: 180      default: 20


### PR DESCRIPTION
## Summary
- correct typo in contact sensor profile
- correct typo in motion sensor profile

## Testing
- `grep -n "the more frequently" drivers/SmartThings/Boundary-sensors/profiles/boundary-contact.yml`
- `grep -n "the more frequently" drivers/SmartThings/Boundary-sensors/profiles/boundary-motion.yml`


------
https://chatgpt.com/codex/tasks/task_e_686d7726efdc8326ad130631bbdc5fae